### PR TITLE
:sparkles: Feat: itemRepository 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/HM/Hanbat_Market/repository/item/ItemRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/item/ItemRepository.java
@@ -1,0 +1,17 @@
+package HM.Hanbat_Market.repository.item;
+
+import HM.Hanbat_Market.domain.entity.Item;
+import HM.Hanbat_Market.domain.entity.Member;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ItemRepository {
+    Item save(Item item);
+
+    Optional<Item> findById(Long id);
+
+    List<Item> findByMember(Member member);
+
+    List<Item> findAll();
+}

--- a/src/main/java/HM/Hanbat_Market/repository/item/JpaItemRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/item/JpaItemRepository.java
@@ -1,0 +1,49 @@
+package HM.Hanbat_Market.repository.item;
+
+import HM.Hanbat_Market.domain.entity.Item;
+import HM.Hanbat_Market.domain.entity.Member;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaItemRepository implements ItemRepository {
+
+    private final EntityManager em;
+
+
+    @Override
+    public Item save(Item item) {
+        //        if (item.getId() == null){
+        //            em.persist(item);
+        //        }else {
+        //            em.merge(item);
+        //        }
+        em.persist(item);
+        return item;
+    }
+
+    @Override
+    public Optional<Item> findById(Long id) {
+        Item item = em.find(Item.class, id);
+        return Optional.ofNullable(item);
+    }
+
+    @Override
+    public List<Item> findByMember(Member member) {
+        Long memberId = member.getId();
+        return em.createQuery("select i from Item i where i.member.id = :memberId")
+                .setParameter("memberId", memberId)
+                .getResultList();
+    }
+
+    @Override
+    public List<Item> findAll() {
+        return em.createQuery("select i from Item i")
+                .getResultList();
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/repository/member/MemberRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/member/MemberRepository.java
@@ -14,5 +14,4 @@ public interface MemberRepository {
     Optional<Member> findByNickName(String name);
 
     List<Member> findAll();
-
 }

--- a/src/test/java/HM/Hanbat_Market/repository/item/JpaItemRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/item/JpaItemRepositoryTest.java
@@ -1,0 +1,95 @@
+package HM.Hanbat_Market.repository.item;
+
+import HM.Hanbat_Market.domain.entity.Item;
+import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.member.JpaMemberRepository;
+import HM.Hanbat_Market.repository.member.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class JpaItemRepositoryTest {
+
+    @Autowired ItemRepository jpaItemRepository;
+    @Autowired MemberRepository jpaMemberRepository;
+
+    @Test
+    public void 아이템_등록() throws Exception {
+        //given
+        Member member = createTestMember();
+        Item item = createTestItem(member);
+        //when
+        jpaItemRepository.save(item);
+        //then
+        assertEquals(item, jpaItemRepository.findById(item.getId()).get());
+    }
+
+    @Test
+    public void 아이템_멤버_테스트() throws Exception {
+        //given
+        Member member = createTestMember();
+        jpaMemberRepository.save(member);
+
+        Item item = createTestItem(member);
+        jpaItemRepository.save(item);
+        //when
+        Member member2 = item.getMember();
+        //then
+        assertEquals(member2, jpaMemberRepository.findById(member.getId()).get());
+    }
+
+    /**
+     * 모든 아이템을 조회하는 것을 테스트 합니다.
+     * 멤버가 갖고 있는 아이템의 수 전체 조회한 아이템의 수를 비교합니다.
+     * 멤버가 갖고 있는 아이템의 수와 멤버의 아이템 수를 조회하여 비교합니다.
+     */
+
+    @Test
+    public void 아이템_전체조회() throws Exception {
+        //given
+        Member member = createTestMember();
+        jpaMemberRepository.save(member);
+
+        Item item = createTestItem(member);
+        Item item2 = createTestItem(member);
+        Item item3 = createTestItem(member);
+        jpaItemRepository.save(item);
+        jpaItemRepository.save(item2);
+        jpaItemRepository.save(item3);
+
+        Member findMember = jpaMemberRepository.findById(member.getId()).get();
+
+        //when
+        List<Item> items = jpaItemRepository.findAll();
+        List<Item> memberItems = jpaItemRepository.findByMember(findMember);
+
+        //then
+        assertEquals(3, items.size());
+        assertEquals(findMember.getItems().size(), items.size());
+        assertEquals(findMember.getItems().size(), memberItems.size());
+    }
+
+    public Member createTestMember() {
+        String mail = "jckim229@gmail.com";
+        String passwd = "1234";
+        String phoneNumber = "010-1234-1234";
+        String nickname = "김주찬";
+
+        return Member.createMember(mail, passwd, phoneNumber, nickname);
+    }
+
+    public Item createTestItem(Member member) {
+        Long price = 10000L;
+        String description = "hello";
+        String tradingPlace = "성수역 7번 출구";
+
+        return Item.createItem(price, description, tradingPlace, member);
+    }
+}

--- a/src/test/java/HM/Hanbat_Market/repository/member/JpaMemberRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/member/JpaMemberRepositoryTest.java
@@ -1,4 +1,4 @@
-package HM.Hanbat_Market.repository;
+package HM.Hanbat_Market.repository.member;
 
 import HM.Hanbat_Market.domain.entity.Member;
 import HM.Hanbat_Market.repository.member.JpaMemberRepository;
@@ -15,8 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 class JpaMemberRepositoryTest
 {
-    @Autowired
-    JpaMemberRepository jpaMemberRepository;
+    @Autowired MemberRepository jpaMemberRepository;
 
     @Test
     public void 회원가입() throws Exception {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 

## 📝작업 내용

- itemRepository 인터페이스를 생성했습니다.
- itemRepository를 구현한 JpaItemRepository를 구현했습니다.
- JpaItemRepository에 대한 테스트 코드를 작성했습니다.
  - 아이템_등록
  - 아이템_전체_조회
  - 아이템_멤버_테스트

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

ItemRepository에서 굳이 멤버별 조회가 필요할지 고민해보면 좋을 것 같습니다.
Member에서 바로 조회가 가능하니까요.
일단 구현은 했습니다.
