### PR TITLE
✨ Feat: 게시글 관련 비즈니스 로직 및 테스트 코드 구현 (#23)

### DIFF
--- a/src/main/java/HM/Hanbat_Market/domain/entity/Article.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Article.java
@@ -1,5 +1,8 @@
 package HM.Hanbat_Market.domain.entity;
 
+import HM.Hanbat_Market.repository.article.dto.ArticleCreateDto;
+import HM.Hanbat_Market.repository.article.dto.ArticleUpdateDto;
+import HM.Hanbat_Market.repository.item.dto.ItemUpdateDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,6 +12,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.awt.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +35,8 @@ public class Article {
 
     private String tradingPlace;
 
+    private ArticleStatus articleStatus;
+
     @OneToOne(mappedBy = "article", cascade = CascadeType.ALL)
     private Item item;
 
@@ -50,6 +56,7 @@ public class Article {
         this.description = description;
         this.tradingPlace = tradingPlace;
         this.createdAt = LocalDateTime.now();
+        this.articleStatus = ArticleStatus.OPEN;
     }
 
     /**
@@ -66,16 +73,28 @@ public class Article {
     }
 
     /**
-     * @param member
-     * @param item   생성 메서드
+     * 생성 메서드
      */
-    public static Article createArticle(String title, String description, String tradingPlace, Member member, Item item) {
-        Article article = new Article(title, description, tradingPlace);
+    public static Article createArticle(ArticleCreateDto articleCreateDto) {
+        Article article = new Article(articleCreateDto.getTitle(),
+                articleCreateDto.getDescription(), articleCreateDto.getTradingPlace());
 
-        article.regisMember(member);
-        article.regisItem(item);
+        article.regisMember(articleCreateDto.getMember());
+        article.regisItem(articleCreateDto.getItem());
 
         return article;
+    }
+
+    public void updateArticle(ArticleUpdateDto articleUpdateDto) {
+        this.title = articleUpdateDto.getTitle();
+        this.description = articleUpdateDto.getDescription();
+        this.tradingPlace = articleUpdateDto.getDescription();
+        this.item.updateItem(articleUpdateDto.getItemUpdateDto());
+    }
+
+    public void deleteArticle() {
+        this.articleStatus = ArticleStatus.HIDE;
+        this.item.deleteItem();
     }
 
 }

--- a/src/main/java/HM/Hanbat_Market/domain/entity/ArticleStatus.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/ArticleStatus.java
@@ -1,0 +1,5 @@
+package HM.Hanbat_Market.domain.entity;
+
+public enum ArticleStatus {
+    OPEN, HIDE;
+}

--- a/src/main/java/HM/Hanbat_Market/domain/entity/ImageFile.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/ImageFile.java
@@ -1,5 +1,6 @@
 package HM.Hanbat_Market.domain.entity;
 
+import HM.Hanbat_Market.repository.article.dto.ImageFileDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,8 +42,8 @@ public class ImageFile {
     /**
      * 생성 메서드
      */
-    public static ImageFile createImageFile(Article article, String type, String path) {
-        ImageFile imageFile = new ImageFile(type, path);
+    public static ImageFile createImageFile(Article article, ImageFileDto imageFileDto) {
+        ImageFile imageFile = new ImageFile(imageFileDto.getType(), imageFileDto.getPath());
         imageFile.regisArticle(article);
         return imageFile;
     }

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Item.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Item.java
@@ -1,5 +1,7 @@
 package HM.Hanbat_Market.domain.entity;
 
+import HM.Hanbat_Market.repository.item.dto.ItemCreateDto;
+import HM.Hanbat_Market.repository.item.dto.ItemUpdateDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -70,8 +72,8 @@ public class Item {
     /**
      * 생성 메서드
      */
-    public static Item createItem(String itemName, Long price, Member member) {
-        Item item = new Item(itemName, price);
+    public static Item createItem(ItemCreateDto itemCreateDto, Member member) {
+        Item item = new Item(itemCreateDto.getItemName(), itemCreateDto.getPrice());
         item.regisMember(member);
         return item;
     }
@@ -79,11 +81,20 @@ public class Item {
     /**
      * 비즈니스 로직
      */
-    public void changeItemStatus() {
+    public void completeItemStatus() {
         if (this.itemStatus == ItemStatus.SALE) {
             this.itemStatus = ItemStatus.COMP;
         } else if (this.itemStatus == ItemStatus.COMP) {
             this.itemStatus = ItemStatus.SALE;
         }
+    }
+
+    public void updateItem(ItemUpdateDto itemUpdateDto){
+        this.price = itemUpdateDto.getPrice();
+        this.itemName = itemUpdateDto.getItemName();
+    }
+
+    public void deleteItem(){
+        this.itemStatus = ItemStatus.HIDE;
     }
 }

--- a/src/main/java/HM/Hanbat_Market/domain/entity/ItemStatus.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/ItemStatus.java
@@ -1,5 +1,5 @@
 package HM.Hanbat_Market.domain.entity;
 
 public enum ItemStatus {
-    SALE, COMP;
+    SALE, COMP, HIDE;
 }

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Member.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Member.java
@@ -42,6 +42,10 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<Purchase> purchases = new ArrayList<>();
 
+    private void setMail(String mail){
+        this.mail = mail;
+    }
+
     private Member(String mail, String passwd, String phoneNumber, String nickname) {
         this.mail = mail;
         this.passwd = passwd;
@@ -51,6 +55,10 @@ public class Member {
 
     public static Member createMember(String mail, String passwd, String phoneNumber, String nickname) {
         return new Member(mail, passwd, phoneNumber, nickname);
+    }
+
+    public void changeMail(String mail) {
+        setMail(mail);
     }
 
 }

--- a/src/main/java/HM/Hanbat_Market/repository/article/ArticleRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/ArticleRepository.java
@@ -1,8 +1,8 @@
 package HM.Hanbat_Market.repository.article;
 
 import HM.Hanbat_Market.domain.entity.Article;
-import HM.Hanbat_Market.domain.entity.Item;
 import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.article.dto.ArticleSearchDto;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/HM/Hanbat_Market/repository/article/JpaArticleRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/JpaArticleRepository.java
@@ -1,15 +1,14 @@
 package HM.Hanbat_Market.repository.article;
 
 import HM.Hanbat_Market.domain.entity.Article;
-import HM.Hanbat_Market.domain.entity.Item;
 import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.article.dto.ArticleSearchDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -61,6 +60,16 @@ public class JpaArticleRepository implements ArticleRepository {
             }
             jpql += " i.itemStatus = :itemStatus";
         }
+        //게시글 제목 검색
+        if (StringUtils.hasText(articleSearchDto.getTitle())) {
+            if (isFirstCondition) {
+                jpql += " where";
+                isFirstCondition = false;
+            } else {
+                jpql += " and";
+            }
+            jpql += "  a.title like concat('%', :title, '%')";
+        }
         //아이템 이름 검색
         if (StringUtils.hasText(articleSearchDto.getItemName())) {
             if (isFirstCondition) {
@@ -69,7 +78,7 @@ public class JpaArticleRepository implements ArticleRepository {
             } else {
                 jpql += " and";
             }
-            jpql += " i.itemName like :itemName";
+            jpql += " i.itemName like concat('%', :itemName, '%')";
         }
         TypedQuery<Article> query = em.createQuery(jpql, Article.class)
                 .setMaxResults(1000); //최대 1000건
@@ -80,6 +89,10 @@ public class JpaArticleRepository implements ArticleRepository {
         if (StringUtils.hasText(articleSearchDto.getItemName())) {
             query = query
                     .setParameter("itemName", articleSearchDto.getItemName());
+        }
+        if (StringUtils.hasText(articleSearchDto.getTitle())) {
+            query = query
+                    .setParameter("title", articleSearchDto.getTitle());
         }
         return query.getResultList();
     }

--- a/src/main/java/HM/Hanbat_Market/repository/article/dto/ArticleCreateDto.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/dto/ArticleCreateDto.java
@@ -1,0 +1,28 @@
+package HM.Hanbat_Market.repository.article.dto;
+
+import HM.Hanbat_Market.domain.entity.ArticleStatus;
+import HM.Hanbat_Market.domain.entity.ImageFile;
+import HM.Hanbat_Market.domain.entity.Item;
+import HM.Hanbat_Market.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class ArticleCreateDto {
+    private String title;
+
+    private String description;
+
+    private String tradingPlace;
+
+    private Item item;
+
+    private Member member;
+
+    private List<ImageFile> imageFiles = new ArrayList<>();
+}

--- a/src/main/java/HM/Hanbat_Market/repository/article/dto/ArticleSearchDto.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/dto/ArticleSearchDto.java
@@ -1,4 +1,4 @@
-package HM.Hanbat_Market.repository.article;
+package HM.Hanbat_Market.repository.article.dto;
 
 import HM.Hanbat_Market.domain.entity.Item;
 import HM.Hanbat_Market.domain.entity.ItemStatus;
@@ -9,6 +9,6 @@ import lombok.Setter;
 @Setter
 public class ArticleSearchDto {
     ItemStatus itemStatus;
-
+    String title;
     String itemName;
 }

--- a/src/main/java/HM/Hanbat_Market/repository/article/dto/ArticleUpdateDto.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/dto/ArticleUpdateDto.java
@@ -1,0 +1,27 @@
+package HM.Hanbat_Market.repository.article.dto;
+
+import HM.Hanbat_Market.domain.entity.ImageFile;
+import HM.Hanbat_Market.domain.entity.Item;
+import HM.Hanbat_Market.repository.item.dto.ItemUpdateDto;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class ArticleUpdateDto {
+    private String title;
+
+    private String description;
+
+    private String tradingPlace;
+
+    private ItemUpdateDto itemUpdateDto;
+
+    private List<ImageFile> imageFiles = new ArrayList<>();
+}

--- a/src/main/java/HM/Hanbat_Market/repository/article/dto/ImageFileDto.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/dto/ImageFileDto.java
@@ -1,0 +1,12 @@
+package HM.Hanbat_Market.repository.article.dto;
+
+import HM.Hanbat_Market.domain.entity.Article;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ImageFileDto {
+    String type;
+    String path;
+}

--- a/src/main/java/HM/Hanbat_Market/repository/item/dto/ItemCreateDto.java
+++ b/src/main/java/HM/Hanbat_Market/repository/item/dto/ItemCreateDto.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.repository.item.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemCreateDto {
+    Long price;
+    String itemName;
+}

--- a/src/main/java/HM/Hanbat_Market/repository/item/dto/ItemUpdateDto.java
+++ b/src/main/java/HM/Hanbat_Market/repository/item/dto/ItemUpdateDto.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.repository.item.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemUpdateDto {
+    Long price;
+    String itemName;
+}

--- a/src/main/java/HM/Hanbat_Market/service/article/ArticleService.java
+++ b/src/main/java/HM/Hanbat_Market/service/article/ArticleService.java
@@ -1,0 +1,83 @@
+package HM.Hanbat_Market.service.article;
+
+import HM.Hanbat_Market.domain.entity.Article;
+import HM.Hanbat_Market.domain.entity.ImageFile;
+import HM.Hanbat_Market.domain.entity.Item;
+import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.article.ArticleRepository;
+import HM.Hanbat_Market.repository.article.dto.ArticleCreateDto;
+import HM.Hanbat_Market.repository.article.dto.ArticleSearchDto;
+import HM.Hanbat_Market.repository.article.dto.ArticleUpdateDto;
+import HM.Hanbat_Market.repository.article.dto.ImageFileDto;
+import HM.Hanbat_Market.repository.item.dto.ItemCreateDto;
+import HM.Hanbat_Market.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+
+    //영속성 전이로 ItemRepository에 따로 persist하지 않아도 됨
+    @Transactional
+    public Long regisArticle(Long memberId, ArticleCreateDto articleCreateDto, ItemCreateDto itemCreateDto) {
+        Member newMember = memberRepository.findById(memberId).get();
+        Item newItem = Item.createItem(itemCreateDto, newMember);
+        articleCreateDto.setItem(newItem);
+        articleCreateDto.setMember(newMember);
+        return articleRepository.save(Article.createArticle(articleCreateDto)).getId();
+    }
+
+    @Transactional
+    public Long regisArticle(Long memberId, ArticleCreateDto articleCreateDto, ItemCreateDto itemCreateDto, List<ImageFileDto> imageFilesDto) {
+        Member newMember = memberRepository.findById(memberId).get();
+        Item newItem = Item.createItem(itemCreateDto, newMember);
+        articleCreateDto.setItem(newItem);
+        articleCreateDto.setMember(newMember);
+
+        Article newArticle = Article.createArticle(articleCreateDto);
+
+        imageFilesDto.stream()
+                .forEach(imageFileDto -> ImageFile
+                        .createImageFile(newArticle, imageFileDto));
+
+        return articleRepository.save(newArticle).getId();
+    }
+
+    //검색
+    public List<Article> findArticles(ArticleSearchDto articleSearchDto) {
+        return articleRepository.findAllBySearch(articleSearchDto);
+    }
+
+    public List<Article> findArticles() {
+        return articleRepository.findAll();
+    }
+
+    public List<Article> findArticles(Member member) {
+        return articleRepository.findAllByMember(member);
+    }
+
+    public Article findArticle(Long articleId) {
+        return articleRepository.findById(articleId).get();
+    }
+
+    @Transactional
+    public void deleteArticle(Long articleId) {
+        Article article = articleRepository.findById(articleId).get();
+        article.deleteArticle();
+    }
+
+    @Transactional
+    public Long updateArticle(Long articleId, ArticleUpdateDto articleUpdateDto) {
+        Article article = articleRepository.findById(articleId).get();
+        article.updateArticle(articleUpdateDto);
+        return articleId;
+    }
+}

--- a/src/test/java/HM/Hanbat_Market/CreateTestEntity.java
+++ b/src/test/java/HM/Hanbat_Market/CreateTestEntity.java
@@ -1,8 +1,16 @@
 package HM.Hanbat_Market;
 
 import HM.Hanbat_Market.domain.entity.Article;
+import HM.Hanbat_Market.domain.entity.ImageFile;
 import HM.Hanbat_Market.domain.entity.Item;
 import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.article.dto.ArticleCreateDto;
+import HM.Hanbat_Market.repository.article.dto.ImageFileDto;
+import HM.Hanbat_Market.repository.item.dto.ItemCreateDto;
+import HM.Hanbat_Market.repository.item.dto.ItemUpdateDto;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CreateTestEntity {
     public static Member createTestMember2() {
@@ -23,22 +31,23 @@ public class CreateTestEntity {
         return Member.createMember(mail, passwd, phoneNumber, nickname);
     }
 
-    public static Item createTestItem(Member member, String name) {
+    public static Item createTestItem(Member member, String name, Long price) {
         String itemName = name;
-        Long price = 10000L;
-        String description = "hello";
-        String tradingPlace = "성수역 7번 출구";
+        ItemCreateDto itemCreateDto = new ItemCreateDto();
+        itemCreateDto.setItemName(itemName);
+        itemCreateDto.setPrice(price);
 
-        return Item.createItem(itemName, price, member);
+        return Item.createItem(itemCreateDto, member);
     }
 
 
     public static Article creteTestArticle(Member member, Item item) {
-        String title = "증고책 팝니다";
-        String description = "hello";
-        String tradingPlace = "성수역 7번 출구";
-
-        return Article.createArticle(title, description, tradingPlace, member, item);
+        ArticleCreateDto articleCreateDto = new ArticleCreateDto();
+        articleCreateDto.setTitle("플레이스테이션5 팝니다.");
+        articleCreateDto.setDescription("이러이러 합니다.");
+        articleCreateDto.setMember(member);
+        articleCreateDto.setItem(item);
+        return Article.createArticle(articleCreateDto);
     }
 
     public static Member createTestMember(String nickname, String mail, String phoneNumber) {
@@ -47,9 +56,52 @@ public class CreateTestEntity {
     }
 
     public static Item createTestItem(Member member) {
-        String ItemName = "PS5";
+        String itemName = "PS5";
         Long price = 10000L;
+        ItemCreateDto itemCreateDto = new ItemCreateDto();
+        itemCreateDto.setItemName(itemName);
+        itemCreateDto.setPrice(price);
 
-        return Item.createItem(ItemName, price, member);
+        return Item.createItem(itemCreateDto, member);
+    }
+
+    public static ItemCreateDto createItemCreateDto(String itemName, Long price) {
+        ItemCreateDto itemCreateDto = new ItemCreateDto();
+        itemCreateDto.setItemName(itemName);
+        itemCreateDto.setPrice(price);
+
+        return itemCreateDto;
+    }
+
+    public static ArticleCreateDto createArticleCreateDto(String title, String description, String tradingPlace) {
+        ArticleCreateDto articleCreateDto = new ArticleCreateDto();
+        articleCreateDto.setTitle(title);
+        articleCreateDto.setDescription(description);
+        articleCreateDto.setTradingPlace(tradingPlace);
+        return articleCreateDto;
+    }
+
+    public static List<ImageFileDto> createTestImageFilesDto() {
+        List<ImageFileDto> imageFilesDto = new ArrayList<>();
+        ImageFileDto imageFileDto1 = new ImageFileDto();
+        imageFileDto1.setPath("/sf");
+        imageFileDto1.setType("png");
+        ImageFileDto imageFileDto2 = new ImageFileDto();
+        imageFileDto2.setPath("/asd");
+        imageFileDto2.setType("jpg");
+
+        imageFilesDto.add(imageFileDto1);
+        imageFilesDto.add(imageFileDto2);
+
+        return imageFilesDto;
+
+    }
+
+    public static ItemUpdateDto createItemUpdateDto() {
+        ItemUpdateDto itemUpdateDto = new ItemUpdateDto();
+        itemUpdateDto.setItemName("수정한 아이템 이름");
+        itemUpdateDto.setPrice(9999L);
+
+        return itemUpdateDto;
     }
 }

--- a/src/test/java/HM/Hanbat_Market/repository/article/JpaArticleRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/article/JpaArticleRepositoryTest.java
@@ -4,8 +4,8 @@ import HM.Hanbat_Market.domain.entity.Article;
 import HM.Hanbat_Market.domain.entity.Item;
 import HM.Hanbat_Market.domain.entity.ItemStatus;
 import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.article.dto.ArticleSearchDto;
 import HM.Hanbat_Market.repository.item.ItemRepository;
-import HM.Hanbat_Market.repository.item.JpaItemRepository;
 import HM.Hanbat_Market.repository.member.MemberRepository;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class JpaArticleRepositoryTest {
     public void 게시글_등록() throws Exception {
         //given
         Member member = createTestMember1();
-        Item item = createTestItem(member, "PS5");
+        Item item = createTestItem(member);
         Article article = creteTestArticle(member, item);
 
         //when
@@ -47,7 +47,7 @@ class JpaArticleRepositoryTest {
         Member member = createTestMember1();
         jpaMemberRepository.save(member);
 
-        Item item = createTestItem(member, "PS5");
+        Item item = createTestItem(member);
         Article article = creteTestArticle(member, item);
 
         jpaArticleRepository.save(article);
@@ -81,9 +81,9 @@ class JpaArticleRepositoryTest {
         jpaMemberRepository.save(member);
         jpaMemberRepository.save(member2);
 
-        Item item = createTestItem(member, "PS3");
-        Item item2 = createTestItem(member, "PS4");
-        Item item3 = createTestItem(member2, "PS5");
+        Item item = createTestItem(member, "PS3", 16000L);
+        Item item2 = createTestItem(member, "PS4", 160000L);
+        Item item3 = createTestItem(member2, "PS5", 160000L);
 
         Article article = creteTestArticle(member, item);
         Article article2 = creteTestArticle(member, item2);
@@ -114,9 +114,9 @@ class JpaArticleRepositoryTest {
         jpaMemberRepository.save(member);
         jpaMemberRepository.save(member2);
 
-        Item item = createTestItem(member, "PS3");
-        Item item2 = createTestItem(member, "PS4");
-        Item item3 = createTestItem(member2, "PS5");
+        Item item = createTestItem(member, "PS3", 16000L);
+        Item item2 = createTestItem(member, "PS4", 160000L);
+        Item item3 = createTestItem(member2, "PS5", 160000L);
 
         Article article = creteTestArticle(member, item);
         Article article2 = creteTestArticle(member, item2);
@@ -136,7 +136,7 @@ class JpaArticleRepositoryTest {
 
         articleSearchDto.setItemName(null);
         articleSearchDto.setItemStatus(ItemStatus.COMP);
-        item.changeItemStatus();
+        item.completeItemStatus();
 
         List<Article> searchByItemStatus = jpaArticleRepository.findAllBySearch(articleSearchDto);
 

--- a/src/test/java/HM/Hanbat_Market/repository/item/JpaImageFileRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/item/JpaImageFileRepositoryTest.java
@@ -6,6 +6,7 @@ import HM.Hanbat_Market.domain.entity.ImageFile;
 import HM.Hanbat_Market.domain.entity.Item;
 import HM.Hanbat_Market.domain.entity.Member;
 import HM.Hanbat_Market.repository.article.ArticleRepository;
+import HM.Hanbat_Market.repository.article.dto.ImageFileDto;
 import HM.Hanbat_Market.repository.member.MemberRepository;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
@@ -37,8 +38,9 @@ class JpaImageFileRepositoryTest {
 
         Item testItem = createTestItem(newMember);
         Article article = creteTestArticle(newMember, testItem);
-        ImageFile imageFile = ImageFile.createImageFile(article, "jpg", "/");
-
+        List<ImageFileDto> testImageFilesDto = createTestImageFilesDto();
+        ImageFile imageFile = ImageFile.createImageFile(article, testImageFilesDto.get(0));
+        
         //when
         jpaArticleRepository.save(article);
 

--- a/src/test/java/HM/Hanbat_Market/service/article/ArticleServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/article/ArticleServiceTest.java
@@ -1,0 +1,137 @@
+package HM.Hanbat_Market.service.article;
+
+import HM.Hanbat_Market.CreateTestEntity;
+import HM.Hanbat_Market.domain.entity.*;
+import HM.Hanbat_Market.repository.article.ArticleRepository;
+import HM.Hanbat_Market.repository.article.dto.ArticleCreateDto;
+import HM.Hanbat_Market.repository.article.dto.ArticleSearchDto;
+import HM.Hanbat_Market.repository.article.dto.ArticleUpdateDto;
+import HM.Hanbat_Market.repository.article.dto.ImageFileDto;
+import HM.Hanbat_Market.repository.item.dto.ItemCreateDto;
+import HM.Hanbat_Market.repository.member.MemberRepository;
+import HM.Hanbat_Market.service.member.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static HM.Hanbat_Market.CreateTestEntity.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ArticleServiceTest {
+    @Autowired
+    ArticleService articleService;
+    @Autowired
+    MemberService memberService;
+
+    @Test
+    public void 게시글_등록() throws Exception {
+        //given
+        Member member = Member.createMember("jckim229@gmail.com", "0303", "01028564221", "김주찬");
+        memberService.join(member);
+        ArticleCreateDto articleCreateDto = createArticleCreateDto("PS5 팝니다.", "싸게 팝니다.", "대전");
+        ItemCreateDto itemCreateDto = createItemCreateDto("PS5", 170000L);
+        List<ImageFileDto> imageFilesDto = createTestImageFilesDto();
+        //when
+        articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto, imageFilesDto);
+        articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
+        //then (등록된 게시글이 2개)
+        assertEquals(2, articleService.findArticles(member).size());
+        assertEquals(2, articleService.findArticles().size());
+
+        //등록된 이미지 파일이 없음
+        assertEquals(0, articleService.findArticles().get(1).getImageFiles().size());
+    }
+
+    @Test
+    public void 게시글_등록_검색() throws Exception {
+        //given
+        Member member = Member.createMember("jckim229@gmail.com", "0303", "01028564221", "김주찬");
+        memberService.join(member);
+
+        ArticleCreateDto articleCreateDto = createArticleCreateDto("PS5 팝니다.", "싸게 팝니다.", "대전");
+        ArticleCreateDto articleCreateDto2 = createArticleCreateDto("PS3 팝니다.", "싸게 팝니다.", "대전");
+        ItemCreateDto itemCreateDto = createItemCreateDto("PS5", 170000L);
+        ItemCreateDto itemCreateDto2 = createItemCreateDto("PS3", 130000L);
+        List<ImageFileDto> imageFilesDto = createTestImageFilesDto();
+
+        ArticleSearchDto articleSearchDto = new ArticleSearchDto();
+        articleSearchDto.setTitle("PS3");
+        //when
+        articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto, imageFilesDto);
+        articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
+        articleService.regisArticle(member.getId(), articleCreateDto2, itemCreateDto2);
+        //then (등록된 게시글이 3개)
+        assertEquals(3, articleService.findArticles(member).size());
+        assertEquals(3, articleService.findArticles().size());
+
+        //then (PS3로 검색한 게시글이 1개)
+        assertEquals(1, articleService.findArticles(articleSearchDto).size());
+        articleSearchDto.setItemName("PS");
+        articleSearchDto.setTitle("");
+
+        //then (PS로 검색한 아이템 이름에 해당하는 게시글이 3개
+        assertEquals(3, articleService.findArticles(articleSearchDto).size());
+
+        //등록된 이미지 파일이 없음
+        assertEquals(0, articleService.findArticles().get(1).getImageFiles().size());
+    }
+
+    @Test
+    public void 게시글_수정() throws Exception {
+        //given
+        Member member = Member.createMember("jckim229@gmail.com", "0303", "01028564221", "김주찬");
+        memberService.join(member);
+
+        ArticleCreateDto articleCreateDto = createArticleCreateDto("PS5 팝니다.", "싸게 팝니다.", "대전");
+        ItemCreateDto itemCreateDto = createItemCreateDto("PS5", 170000L);
+        List<ImageFileDto> imageFilesDto = createTestImageFilesDto();
+
+        Long articleId = articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
+        Article article = articleService.findArticle(articleId);
+
+        //when
+        ArticleUpdateDto articleUpdateDto = new ArticleUpdateDto();
+        articleUpdateDto.setTitle("수정한 게시글 제목");
+        articleUpdateDto.setDescription("qwer");
+        articleUpdateDto.setItemUpdateDto(createItemUpdateDto());
+        articleUpdateDto.setTradingPlace("sdf");
+        imageFilesDto.stream()
+                .forEach(imageFileDto -> ImageFile.createImageFile(article, imageFileDto));
+
+        articleService.updateArticle(articleId, articleUpdateDto);
+
+        //then (수정된 게시글 제목으로 검색)
+        ArticleSearchDto articleSearchDto = new ArticleSearchDto();
+        articleSearchDto.setTitle("수정한");
+        assertEquals(1, articleService.findArticles(articleSearchDto).size());
+
+        //then (등록한 이미지 파일 2개)
+        assertEquals(2, articleService.findArticles().get(0).getImageFiles().size());
+
+    }
+
+    @Test
+    public void 게시글_삭제() throws Exception {
+        //given
+        Member member = Member.createMember("jckim229@gmail.com", "0303", "01028564221", "김주찬");
+        memberService.join(member);
+
+        ArticleCreateDto articleCreateDto = createArticleCreateDto("PS5 팝니다.", "싸게 팝니다.", "대전");
+        ItemCreateDto itemCreateDto = createItemCreateDto("PS5", 170000L);
+
+        Long articleId = articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
+
+        //when (상태를 변경하는 것으로 softDelete 진행
+        articleService.deleteArticle(articleId);
+
+        //then
+        assertEquals(ArticleStatus.HIDE, articleService.findArticles(member).get(0).getArticleStatus());
+    }
+
+}

--- a/src/test/java/HM/Hanbat_Market/service/member/MemberServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/member/MemberServiceTest.java
@@ -38,12 +38,16 @@ class MemberServiceTest {
         //when, then
         memberService.join(member1);
 
-        //변경 감지로 인한 update
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ()
                 -> memberService.join(member2));
         assertEquals("이미 존재하는 닉네임입니다.", e.getMessage());
 
+        //변경 감지로 인한 update
+        member1.changeMail("123@gmail.com");
+        Member findMember1 = jpaMemberRepository.findById(member1.getId()).get();
+
         assertEquals(1, jpaMemberRepository.findAll().size());
+        assertEquals("123@gmail.com", findMember1.getMail());
     }
 
     @Test
@@ -58,12 +62,9 @@ class MemberServiceTest {
         //when, then
         memberService.join(member1);
 
-        //변경 감지로 인한 update
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ()
                 -> memberService.join(member2));
         assertEquals("이미 존재하는 메일입니다.", e.getMessage());
-
-        assertEquals(1, jpaMemberRepository.findAll().size());
     }
 
     @Test
@@ -78,11 +79,8 @@ class MemberServiceTest {
         //when, then
         memberService.join(member1);
 
-        //변경 감지로 인한 update
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ()
                 -> memberService.join(member2));
         assertEquals("이미 존재하는 전화번호입니다.", e.getMessage());
-
-        assertEquals(1, jpaMemberRepository.findAll().size());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

- 게시글 CRUD관련 DTO 생성
- 아이템 CRUD관련 DTO 생성
- ArticleService 추가
  - update, delete 추가
- CRUD 관련 테스트 코드 작성

### 스크린샷 (선택)

![스크린샷 2024-02-06 오후 3 36 38](https://github.com/jckim22/Hanbat_Market/assets/101490157/ef48d703-2251-4bfe-9795-e80a12a1b162)

## 💬리뷰 요구사항(선택)

ImageFiles를 Article에 연관관계로 추가하는 과정을 조금 다듬을 필요가 있습니다.
Article에서 관리할지 ImageFile에서 Article에 직접 등록할지 정해야합니다. (현재는 후자입니다.)
