### PR TITLE
✨ Feat: 관심 상품 관련 비즈니스 로직 구현 및 테스트 (#27)

### DIFF
--- a/src/main/java/HM/Hanbat_Market/domain/entity/PreemptionItem.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/PreemptionItem.java
@@ -25,6 +25,8 @@ public class PreemptionItem {
     @JoinColumn(name = "item_id")
     private Item item;
 
+    private PreemptionItemStatus preemptionItemStatus;
+
     /**
      * 연관관계 편의 메서드
      */
@@ -38,10 +40,23 @@ public class PreemptionItem {
         item.getPreemptionItems().add(this);
     }
 
+    /**
+     * 비즈니스 로직
+     */
+
     public static PreemptionItem createPreemptionItem(Member member, Item item) {
         PreemptionItem preemptionItem = new PreemptionItem();
         preemptionItem.regisItem(item);
         preemptionItem.regisMember(member);
+        preemptionItem.preemptionItemStatus = PreemptionItemStatus.PREEMPTION;
         return preemptionItem;
+    }
+
+    public void active(){
+        this.preemptionItemStatus = PreemptionItemStatus.PREEMPTION;
+    }
+
+    public void cancel(){
+        this.preemptionItemStatus = PreemptionItemStatus.CANCEL;
     }
 }

--- a/src/main/java/HM/Hanbat_Market/domain/entity/PreemptionItemStatus.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/PreemptionItemStatus.java
@@ -1,0 +1,5 @@
+package HM.Hanbat_Market.domain.entity;
+
+public enum PreemptionItemStatus {
+    PREEMPTION, CANCEL
+}

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Trade.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Trade.java
@@ -49,6 +49,9 @@ public class Trade {
         item.setTrade(this);
     }
 
+    /**
+     * 비즈니스 로직
+     */
     public static Trade reservation(Member member, Item item) {
         Trade trade = new Trade();
         trade.regisItem(item);

--- a/src/main/java/HM/Hanbat_Market/repository/item/JpaPreemptionItemRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/item/JpaPreemptionItemRepository.java
@@ -1,8 +1,6 @@
 package HM.Hanbat_Market.repository.item;
 
-import HM.Hanbat_Market.domain.entity.Item;
-import HM.Hanbat_Market.domain.entity.Member;
-import HM.Hanbat_Market.domain.entity.PreemptionItem;
+import HM.Hanbat_Market.domain.entity.*;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -12,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class JpaPreemptionItemRepository implements PreemptionItemRepository{
+public class JpaPreemptionItemRepository implements PreemptionItemRepository {
 
     private final EntityManager em;
 
@@ -36,22 +34,29 @@ public class JpaPreemptionItemRepository implements PreemptionItemRepository{
     @Override
     public List<PreemptionItem> findAllByMember(Member member) {
         Long memberId = member.getId();
-        return em.createQuery("select p from PreemptionItem p join p.member m where m.id = :memberId")
+        return em.createQuery("select p from PreemptionItem p join p.member m where m.id = :memberId" +
+                        " and p.item.itemStatus = :itemStatus and p.preemptionItemStatus != :preemptionItemStatus", PreemptionItem.class)
                 .setParameter("memberId", member.getId())
+                .setParameter("itemStatus", ItemStatus.SALE)
+                .setParameter("preemptionItemStatus", PreemptionItemStatus.CANCEL)
                 .getResultList();
     }
 
     @Override
     public List<PreemptionItem> findAllByItem(Item item) {
         Long itemId = item.getId();
-        return em.createQuery("select p from PreemptionItem p join p.item i where i.id = :itemId")
+        return em.createQuery("select p from PreemptionItem p join p.item i where i.id = :itemId" +
+                        " and i.itemStatus = :itemStatus and p.preemptionItemStatus != :preemptionItemStatus", PreemptionItem.class)
                 .setParameter("itemId", item.getId())
+                .setParameter("itemStatus", ItemStatus.SALE)
+                .setParameter("preemptionItemStatus", PreemptionItemStatus.CANCEL)
                 .getResultList();
     }
 
     @Override
     public List<PreemptionItem> findAll() {
-        return em.createQuery("select p from PreemptionItem p")
+        return em.createQuery("select p from PreemptionItem p where p.preemptionItemStatus != :preemptionItemStatus")
+                .setParameter("preemptionItemStatus", PreemptionItemStatus.CANCEL)
                 .getResultList();
     }
 }

--- a/src/main/java/HM/Hanbat_Market/service/preemption/PreemptionItemService.java
+++ b/src/main/java/HM/Hanbat_Market/service/preemption/PreemptionItemService.java
@@ -1,0 +1,62 @@
+package HM.Hanbat_Market.service.preemption;
+
+import HM.Hanbat_Market.domain.entity.*;
+import HM.Hanbat_Market.repository.item.ItemRepository;
+import HM.Hanbat_Market.repository.item.PreemptionItemRepository;
+import HM.Hanbat_Market.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PreemptionItemService {
+
+    private final PreemptionItemRepository preemptionItemRepository;
+    private final MemberRepository memberRepository;
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    public Long regisPreemption(Long memberId, Long itemId) {
+        Member member = memberRepository.findById(memberId).get();
+        Item item = itemRepository.findById(itemId).get();
+        PreemptionItem preemptionItem = PreemptionItem.createPreemptionItem(member, item);
+
+        preemptionItemRepository.save(preemptionItem);
+
+        return preemptionItem.getId();
+    }
+
+    //판매자가 판매를 완료하거나 구매자를 확실히 결정하면 구매완료
+    @Transactional
+    public Long cancelPreemption(Long preemptionItemId) {
+        PreemptionItem preemptionItem = preemptionItemRepository.findById(preemptionItemId).get();
+        preemptionItem.cancel();
+        return preemptionItemId;
+    }
+
+    @Transactional
+    public Long activePreemption(Long preemptionItemId) {
+        PreemptionItem preemptionItem = preemptionItemRepository.findById(preemptionItemId).get();
+        preemptionItem.active();
+        return preemptionItemId;
+    }
+
+    //회원별 관심상품 조회
+    public List<PreemptionItem> findPreemptionItemByMember(Member member) {
+        return preemptionItemRepository.findAllByMember(member);
+    }
+
+    //아이템별 관심상품 조회
+    public List<PreemptionItem> findPreemptionItemByItem(Item item) {
+        return preemptionItemRepository.findAllByItem(item);
+    }
+
+    //전체조회
+    public List<PreemptionItem> findAllPreemptionItem(){
+        return preemptionItemRepository.findAll();
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/service/trade/TradeService.java
+++ b/src/main/java/HM/Hanbat_Market/service/trade/TradeService.java
@@ -63,5 +63,4 @@ public class TradeService {
         }
         trade.cancel();
     }
-
 }

--- a/src/test/java/HM/Hanbat_Market/service/preemption/PreemptionItemServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/preemption/PreemptionItemServiceTest.java
@@ -1,0 +1,68 @@
+package HM.Hanbat_Market.service.preemption;
+
+import HM.Hanbat_Market.domain.entity.*;
+import HM.Hanbat_Market.repository.item.ItemRepository;
+import HM.Hanbat_Market.repository.item.PreemptionItemRepository;
+import HM.Hanbat_Market.service.article.ArticleService;
+import HM.Hanbat_Market.service.member.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static HM.Hanbat_Market.CreateTestEntity.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class PreemptionItemServiceTest {
+    @Autowired
+    PreemptionItemService preemptionItemService;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    ArticleService articleService;
+    @Autowired
+    ItemRepository itemRepository;
+    @Autowired
+    PreemptionItemRepository preemptionItemRepository;
+
+    @Test
+    public void 관심_상품_등록() throws Exception {
+        //given
+        Member testMember = createTestMember1();
+        memberService.join(testMember);
+
+        Long articleId = articleService.regisArticle(testMember.getId(), createArticleCreateDto("test title", "test des", "대전"),
+                createItemCreateDto("플스", 170000L));
+        Article article = articleService.findArticle(articleId);
+        Item item = itemRepository.findById(article.getItem().getId()).get();
+        //when
+        Long preemptionItemId = preemptionItemService.regisPreemption(testMember.getId(), item.getId());
+        //then
+        PreemptionItem preemptionItem = preemptionItemRepository.findById(preemptionItemId).get();
+
+        assertEquals(preemptionItem, preemptionItemService.findPreemptionItemByMember(testMember).get(0));
+        assertEquals(preemptionItem, preemptionItemService.findPreemptionItemByItem(item).get(0));
+        assertEquals(PreemptionItemStatus.PREEMPTION, preemptionItem.getPreemptionItemStatus());
+    }
+
+    @Test
+    public void 관심_상품_취소() throws Exception {
+        //given
+        Member testMember = createTestMember1();
+        memberService.join(testMember);
+
+        Long articleId = articleService.regisArticle(testMember.getId(), createArticleCreateDto("test title", "test des", "대전"),
+                createItemCreateDto("플스", 170000L));
+        Article article = articleService.findArticle(articleId);
+        Item item = itemRepository.findById(article.getItem().getId()).get();
+        Long preemptionItemId = preemptionItemService.regisPreemption(testMember.getId(), item.getId());
+        PreemptionItem preemptionItem = preemptionItemRepository.findById(preemptionItemId).get();
+        //when
+        preemptionItemService.cancelPreemption(preemptionItemId);
+        //then
+        assertEquals(0, preemptionItemService.findAllPreemptionItem().size());
+        assertEquals(PreemptionItemStatus.CANCEL, preemptionItem.getPreemptionItemStatus());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

- 관심상품 상태 추가
  - PreemptionItemStatus (PREEMPTION, CANCEL)
- 관심상품 클래스 비즈니스 로직 추가
  - regisPreemptionItem
  - active
  - cancel
- PreemptionItemService 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)